### PR TITLE
Module 3 – Lecture 2 (Addition & Scalar Multiplication): proper LaTeX, examples, and structure

### DIFF
--- a/Module 3/readme.md
+++ b/Module 3/readme.md
@@ -4,21 +4,32 @@ Welcome! In this module we quickly review the linear‑algebra building blocks y
 
 ## 📚 Table of Contents
 - [Lecture 1: Matrices and Vectors](#lecture-1-matrices-and-vectors)
-  - [What is a matrix?](#what-is-a-matrix)
-  - [Matrix dimensions](#matrix-dimensions)
-  - [Referring to entries: Aᵢⱼ](#referring-to-entries-aᵢⱼ)
-  - [What is a vector?](#what-is-a-vector)
-  - [Vector dimension and Rⁿ](#vector-dimension-and-rⁿ)
-  - [Vector examples](#vector-examples)
-  - [Vector indexing: yᵢ (and 1‑ vs 0‑indexing)](#vector-indexing-y-and-1--vs-0--indexing)
+  - [Matrices (definitions and notation)](#matrices-definitions-and-notation)
+    - [What is a matrix?](#what-is-a-matrix)
+    - [Matrix dimensions](#matrix-dimensions)
+    - [Set notation](#set-notation)
+    - [Referring to entries: Aᵢⱼ](#referring-to-entries-aᵢⱼ)
+  - [Vectors (definitions and notation)](#vectors-definitions-and-notation)
+    - [What is a vector?](#what-is-a-vector)
+    - [Vector dimension and Rⁿ](#vector-dimension-and-rⁿ)
+    - [Vector examples](#vector-examples)
+    - [Vector indexing: yᵢ (and 1‑ vs 0‑indexing)](#vector-indexing-y-and-1--vs-0--indexing)
   - [Common notation conventions](#common-notation-conventions)
   - [Quick reference](#quick-reference)
+- [Lecture 2: Addition and Scalar Multiplication](#lecture-2-addition-and-scalar-multiplication)
+  - [1. Matrix addition and subtraction](#1-matrix-addition-and-subtraction)
+  - [2. Scalar multiplication and division](#2-scalar-multiplication-and-division)
+  - [3. Worked example: combine add/subtract and scalars](#3-worked-example-combine-addsubtract-and-scalars)
+  - [4. Dimension rules to remember](#4-dimension-rules-to-remember)
+  - [5. Key takeaways](#5-key-takeaways)
 
 ---
 
 ## Lecture 1: Matrices and Vectors
 
-### What is a matrix ?
+### Matrices (definitions and notation)
+
+#### What is a matrix ?
 A matrix is a rectangular array of numbers written between square brackets. Think of it as a 2‑D table of numbers.
 
 Example matrices:
@@ -62,7 +73,9 @@ A₂₃ = 1   (row 2, col 3)
 A₂₁ = 9   (row 2, col 1)
 ```
 
-### What is a vector?
+### Vectors (definitions and notation)
+
+#### What is a vector?
 A vector is a special case of a matrix that has only one column — an `n × 1` matrix (a column vector).
 
 Example (a 4‑dimensional vector):
@@ -79,7 +92,7 @@ Example (a 4‑dimensional vector):
 
 -  $\mathbb{R}^{4}$: The set of all 4-dimensional real-valued vectors.
 
-### Vector examples
+#### Vector examples
 - 2‑D vector in $\mathbb{R}^2$ (e.g., a point on a plane):
 
 ```
@@ -138,3 +151,162 @@ y₁ = 4,  y₂ = 6,  y₃ = 3,  y₄ = 8
 > Tip: Don’t worry about memorizing every symbol. Keep this page handy as a mini‑cheat‑sheet and refer back whenever you need a reminder.
 
 
+
+---
+
+## Lecture 2: Addition and Scalar Multiplication
+
+In this lecture we learn how to add/subtract matrices and vectors, and how to multiply/divide them by a number (a “scalar”). All rules are simple and consistent once you remember the shape (dimensions).
+
+### 1. Matrix addition and subtraction
+- You add matrices element‑by‑element.
+- You can only add (or subtract) matrices of the **same size**.
+- Result has the **same size** as the inputs.
+
+Addition:
+
+$$
+\begin{bmatrix}
+a & b \\
+c & d
+\end{bmatrix}
+\ + \
+\begin{bmatrix}
+w & x \\
+y & z
+\end{bmatrix}
+\ = \
+\begin{bmatrix}
+a{+}w & b{+}x \\
+c{+}y & d{+}z
+\end{bmatrix}
+$$
+
+Subtraction:
+
+$$
+\begin{bmatrix}
+a & b \\
+c & d
+\end{bmatrix}
+\ - \
+\begin{bmatrix}
+w & x \\
+y & z
+\end{bmatrix}
+\ = \
+\begin{bmatrix}
+a{-}w & b{-}x \\
+c{-}y & d{-}z
+\end{bmatrix}
+$$
+
+Example (3 × 2 matrices):
+
+```
+⎡ 1  2 ⎤   ⎡ 4  2 ⎤   ⎡ 5  4 ⎤
+⎢ 3  0 ⎥ + ⎢ 0  5 ⎥ = ⎢ 3  5 ⎥
+⎣ 5  1 ⎦   ⎣ 6  1 ⎦   ⎣11  2 ⎦
+```
+**Why this works:**
+- Both matrices have the **same dimensions (3 × 2)**.
+- The **sum** also has **dimension 3 × 2** (same as the inputs).
+
+**Not allowed:** sizes differ (e.g., **3 × 2** plus **2 × 2**) → the sum is **undefined (error)**.
+
+Vectors follow the same rule because a column vector is an `n × 1` matrix.
+
+### 2. Scalar multiplication and division
+- Multiply a matrix by a number by multiplying **each entry** by that number.
+- Division by a number is the same as multiplying by its reciprocal.
+
+Multiplication:
+
+$$
+\begin{bmatrix}
+a & b \\
+c & d
+\end{bmatrix}
+\ . \
+x= \
+\begin{bmatrix}
+a{.}x & b{.}x \\
+c{.}x & d{.}x
+\end{bmatrix}
+$$
+
+
+Division:
+
+$$
+\begin{bmatrix}
+a & b \\
+c & d
+\end{bmatrix}
+\ / \
+x= \
+\begin{bmatrix}
+a{/}x & b{/}x \\
+c{/}x & d{/}x
+\end{bmatrix}
+$$
+
+Example (multiply by 3):
+
+```
+3 · ⎡ 1  2 ⎤ = ⎡  3   6 ⎤
+    ⎢ 3  0 ⎥   ⎢  9   0 ⎥
+    ⎣ 5  1 ⎦   ⎣ 15   3 ⎦
+```
+
+Example (divide by 4):
+
+```
+(1/4) · ⎡ 4  0 ⎤ = ⎡ 1      0   ⎤
+        ⎣ 6  3 ⎦   ⎣ 6/4   3/4  ⎦
+```
+
+Note : `3 × A = A × 3` for any matrix `A` and any real number. You can put the number before or after the matrix — the result is the same.
+
+### 3. Worked example: combine add/subtract and scalars
+Compute
+
+```
+3·⎡1⎤   +   ⎡0⎤   −   (1/3)·⎡3⎤
+  ⎢4⎥       ⎢0⎥             ⎢0⎥
+  ⎣2⎦       ⎣5⎦             ⎣2⎦
+```
+
+Steps:
+1) Scalar multiply/divide
+
+```
+3 × [1, 4, 2]   = [3, 12, 6]
+(1/3) × [3, 0, 2] = [1, 0, 2/3]
+```
+
+2) Add/Subtract element‑wise
+
+```
+[3, 12, 6] + [0, 0, 5] − [1, 0, 2/3]
+= [3 − 1, 12 − 0, 11 − 2/3]
+= [2, 12, 31/3]
+```
+
+Result: a 3 × 1 matrix (3‑D vector)
+
+```
+⎡  2   ⎤
+⎢  12  ⎥
+⎣ 31/3 ⎦
+```
+
+### 4. Dimension rules to remember
+- Add/Subtract: sizes must match (`m×n` with `m×n`).
+- Scalar × Matrix/Vector: always OK; output keeps the same size.
+
+### 5. Key takeaways
+- Addition/subtraction: element‑wise, same sizes only.
+- Scalar multiplication/division: element‑wise; multiply every entry.
+- Vectors follow the same rules since they are `n × 1` matrices.
+- Always keep an eye on the dimensions before you operate.


### PR DESCRIPTION
Summary of changes

- Fixed LaTeX blocks so GitHub renders matrices (removed escaped spacing like “\ + \”, “\ = \”, etc.; used +, −, and \cdot).
- Added general formulas:
- Addition: [a b; c d] + [w x; y z] = [a+w b+x; c+y d+z]
- Subtraction: [a b; c d] − [w x; y z] = [a−w b−x; c−y d−z]
- Converted scalar multiplication/division to consistent LaTeX matrix format and kept short numeric examples.
- Corrected the worked example: 3·[1,4,2] + [0,0,5] − (1/3)·[3,0,2] → [2,12,31/3]^T.
- Improved wording:
- “Why this works” highlights equal dimensions
- “Not allowed” clearly marks mismatched dimensions as undefined (error)
- Restructured Lecture 2 with numbered headings and updated TOC links.